### PR TITLE
feat: add dark mode toggle feature

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,9 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:provider/provider.dart'; 
+import 'package:NagarVikas/theme/theme_provider.dart'; 
+
 
 
 // 🔧 Background message handler for Firebase

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,7 +55,13 @@ void main() async {
   FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
   // ✅ Run the app
-  runApp(const MyApp());
+  runApp(
+  ChangeNotifierProvider(
+    create: (_) => ThemeProvider(),
+    child: const MyApp(),
+  ),
+);
+  
 }
 
 // ✅ Main Application Widget
@@ -64,14 +70,24 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final themeProvider = Provider.of<ThemeProvider>(context);
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'NagarVikas',
       theme: ThemeData(
+        brightness: Brightness.light,
         textTheme: GoogleFonts.nunitoTextTheme(),
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
+      
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
+        textTheme: GoogleFonts.nunitoTextTheme(ThemeData.dark().textTheme),
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      themeMode: themeProvider.isDarkMode ? ThemeMode.dark : ThemeMode.light,
       home: const AuthCheckScreen(),
     );
   }
@@ -211,6 +227,38 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   Widget build(BuildContext context) { 
     return Scaffold(
       backgroundColor: const Color.fromARGB(255, 253, 253, 253),
+  drawer: Drawer(
+    child: ListView(
+      padding: EdgeInsets.zero,
+      children: <Widget>[
+        const DrawerHeader(
+          decoration: BoxDecoration(
+            color: Colors.deepPurple,
+          ),
+          child: Text(
+            'Settings',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+            ),
+          ),
+        ),
+        Consumer<ThemeProvider>(
+          builder: (context, themeProvider, _) => SwitchListTile(
+            title: const Text("Dark Mode"),
+            value: themeProvider.isDarkMode,
+            onChanged: (value) => themeProvider.toggleTheme(),
+            secondary: const Icon(Icons.dark_mode),
+          ),
+        ),
+        ListTile(
+          leading: const Icon(Icons.logout),
+          title: const Text("Logout"),
+          onTap: () => handleLogout(context),
+        ),
+      ],
+    ),
+  ),
       body: Padding(
         padding: const EdgeInsets.all(20.0),
         child: Column(

--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  bool _isDarkMode = false;
+
+  bool get isDarkMode => _isDarkMode;
+
+  ThemeProvider() {
+    _loadTheme();
+  }
+
+  void toggleTheme() {
+    _isDarkMode = !_isDarkMode;
+    _saveTheme(_isDarkMode);
+    notifyListeners();
+  }
+
+  void _loadTheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    _isDarkMode = prefs.getBool('isDarkMode') ?? false;
+    notifyListeners();
+  }
+
+  void _saveTheme(bool isDark) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('isDarkMode', isDark);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -660,10 +660,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1129,10 +1129,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## Purpose 
Issue no. #5 

Added a dark mode toggle to switch between light and dark themes in the app.

## Changes Made

* Added a theme toggle button (light/dark mode)
* Defined and applied `ThemeData` for both modes
* Ensured the theme works across all screens

## Testing Status

1. Couldn't test fully due to Firebase configuration issues
2. Logic and UI changes reviewed, looks fine
3. Request: Please test functionality during review on your side

## Review Notes

* Check if the dark mode applies cleanly across all pages
* Let me know if any design tweaks are needed
* Open to feedback on improving UX or storing preferences