### PR TITLE
Add Share App option in Drawer

### DIFF
--- a/lib/screen/issue_selection.dart
+++ b/lib/screen/issue_selection.dart
@@ -26,6 +26,7 @@ import 'discussion.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:animate_do/animate_do.dart';
 import 'package:onesignal_flutter/onesignal_flutter.dart';
+import 'package:share_plus/share_plus.dart';
 
 // Main Stateful Widget for Issue Selection Page
 class IssueSelectionPage extends StatefulWidget {
@@ -336,7 +337,15 @@ Future<void> _loadAppVersion() async {
         buildDrawerItem(context, Icons.info, "About App", AboutAppPage()),
         buildDrawerItem(
             context, Icons.headset_mic, "Contact Us", ContactUsPage()),
-
+        // Share App    
+           ListTile(
+                leading: Icon(Icons.share),
+                title: Text('Share App'),
+                onTap: () {
+                  Share.share(
+                      'Check out this app: https://github.com/Prateek9876/NagarVikas');
+                },
+              ),
         // Logout Option
         ListTile(
           leading: const Icon(Icons.logout),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,8 @@ dependencies:
   geocoding: ^3.0.0
   lottie: ^3.3.1
   connectivity_plus: ^6.1.4
+  provider: ^6.1.2
+  share_plus: ^7.2.1
        
  
 dev_dependencies:


### PR DESCRIPTION
Added a "Share App" option in the navigation drawer using the share_plus plugin. 
Changes:
Added share_plus dependency to pubspec.yaml
Implemented Share App functionality in AppDrawer class
Currently shares GitHub repo link (placeholder for future app store link)