### PR TITLE
fix: Added Missed Dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,4 +46,5 @@ flutter {
 
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.9.0')
+    implementation 'com.google.firebase:firebase-messaging:23.4.1'
 }


### PR DESCRIPTION
## Description

This PR fixes a runtime crash caused by the absence of the Firebase Cloud Messaging dependency in `android/app/build.gradle`.  
The app was unable to locate `MyFirebaseMessagingService`, resulting in a `ClassNotFoundException` on launch.  
This was resolved by adding the following line under the `dependencies` block:

```gradle
implementation 'com.google.firebase:firebase-messaging:23.4.1'
```

Fixes #55 

## Type of Change

- [x] Bug Fix

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/266456c6-5af4-4119-87d6-a524023a2e68)

After:
![image](https://github.com/user-attachments/assets/5b69c434-c1a8-47b9-878f-69f79272568d)

## How Has This Been Tested?

- Ran the app on physical device
- Verified no crash on startup
- Confirmed MyFirebaseMessagingService is now recognized
- Received a test push notification from Firebase

## Checklist
 
- [x] I have performed a self-review of my code
- [x] The build completes without errors
- [x] The change fixes the root cause of the crash
- [x] This PR is linked to a relevant issue
- [x] No unrelated files were modified in this PR

This was a platform-specific issue that blocked Firebase Messaging functionality and caused the app to crash at runtime.
The fix ensures stability for any features depending on FCM.