### PR TITLE
Added Home , Analytics and Log out feature on Admin Dashboard Navbar

### DIFF
--- a/lib/screen/admin_dashboard.dart
+++ b/lib/screen/admin_dashboard.dart
@@ -14,6 +14,7 @@ class AdminDashboard extends StatefulWidget {
 }
 
 class _AdminDashboardState extends State<AdminDashboard> {
+  int _selectedIndex = 0; // Home is selected by default
   int totalComplaints = 0;
   int pendingComplaints = 0;
   int inProgressComplaints = 0;
@@ -21,9 +22,24 @@ class _AdminDashboardState extends State<AdminDashboard> {
 
   List<Map<String, dynamic>> complaints = [];
   List<Map<String, dynamic>> filteredComplaints = [];
-
   TextEditingController searchController = TextEditingController();
   StreamSubscription? _complaintsSubscription;
+
+  // Bottom navigation items
+  static const List<BottomNavigationBarItem> _bottomNavItems = [
+    BottomNavigationBarItem(
+      icon: Icon(Icons.home),
+      label: 'Home',
+    ),
+    BottomNavigationBarItem(
+      icon: Icon(Icons.analytics),
+      label: 'Analytics',
+    ),
+    BottomNavigationBarItem(
+      icon: Icon(Icons.logout),
+      label: 'Logout',
+    ),
+  ];
 
   @override
   void initState() {
@@ -141,6 +157,55 @@ class _AdminDashboardState extends State<AdminDashboard> {
         const curve = Curves.easeInOut;
         final tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
         return SlideTransition(position: animation.drive(tween), child: child);
+      },
+    );
+  }
+
+  // Handle bottom navigation item tap
+  void _onItemTapped(int index) {
+    if (index == 1) { // Analytics
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const AnalyticsDashboard()),
+      );
+    } else if (index == 2) { // Logout
+      _showLogoutDialog();
+    } else {
+      setState(() {
+        _selectedIndex = index;
+      });
+    }
+  }
+
+  // Show logout confirmation dialog
+  Future<void> _showLogoutDialog() async {
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Confirm Logout'),
+          content: const Text('Are you sure you want to log out?'),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () async {
+                await FirebaseAuth.instance.signOut();
+                if (!mounted) return;
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const LoginPage()),
+                );
+              },
+              child: const Text(
+                'Logout',
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+          ],
+        );
       },
     );
   }
@@ -337,6 +402,19 @@ class _AdminDashboardState extends State<AdminDashboard> {
             ),
           ],
         ),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: _bottomNavItems,
+        currentIndex: _selectedIndex,
+        selectedItemColor: Colors.teal,
+        unselectedItemColor: Colors.grey,
+        onTap: _onItemTapped,
+        type: BottomNavigationBarType.fixed,
+        backgroundColor: Theme.of(context).brightness == Brightness.dark 
+            ? Colors.grey[900] 
+            : Colors.white,
+        elevation: 10,
+        selectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold),
       ),
     );
   }

--- a/lib/screen/analytics_dashboard.dart
+++ b/lib/screen/analytics_dashboard.dart
@@ -4,6 +4,9 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
 import 'package:NagarVikas/widgets/bar_chart_widget.dart';
 import 'package:NagarVikas/widgets/pie_chart_widget.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'admin_dashboard.dart';
+import 'login_page.dart';
 
 class AnalyticsDashboard extends StatefulWidget {
   const AnalyticsDashboard({super.key});
@@ -13,6 +16,7 @@ class AnalyticsDashboard extends StatefulWidget {
 }
 
 class _AnalyticsDashboardState extends State<AnalyticsDashboard> {
+  int _selectedIndex = 1; // Analytics is selected by default
   int resolved = 0;
   int pending = 0;
   int rejected = 0;
@@ -21,10 +25,75 @@ class _AnalyticsDashboardState extends State<AnalyticsDashboard> {
 
   List<Widget> dashboardWidgets = [];
 
+  // Bottom navigation items
+  static const List<BottomNavigationBarItem> _bottomNavItems = [
+    BottomNavigationBarItem(
+      icon: Icon(Icons.home),
+      label: 'Home',
+    ),
+    BottomNavigationBarItem(
+      icon: Icon(Icons.analytics),
+      label: 'Analytics',
+    ),
+    BottomNavigationBarItem(
+      icon: Icon(Icons.logout),
+      label: 'Logout',
+    ),
+  ];
+
   @override
   void initState() {
     super.initState();
     fetchComplaintStats();
+  }
+
+  // Handle bottom navigation item tap
+  void _onItemTapped(int index) {
+    if (index == 0) { // Home
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const AdminDashboard()),
+      );
+    } else if (index == 2) { // Logout
+      _showLogoutDialog();
+    } else {
+      setState(() {
+        _selectedIndex = index;
+      });
+    }
+  }
+
+  // Show logout confirmation dialog
+  Future<void> _showLogoutDialog() async {
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Confirm Logout'),
+          content: const Text('Are you sure you want to log out?'),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () async {
+                await FirebaseAuth.instance.signOut();
+                if (!mounted) return;
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const LoginPage()),
+                );
+              },
+              child: const Text(
+                'Logout',
+                style: TextStyle(color: Colors.red),
+              ),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   void fetchComplaintStats() async {
@@ -216,8 +285,18 @@ class _AnalyticsDashboardState extends State<AnalyticsDashboard> {
                   },
                 ),
               ),
+        bottomNavigationBar: BottomNavigationBar(
+          items: _bottomNavItems,
+          currentIndex: _selectedIndex,
+          selectedItemColor: Colors.teal,
+          unselectedItemColor: Colors.grey,
+          onTap: _onItemTapped,
+          type: BottomNavigationBarType.fixed,
+          backgroundColor: isDarkMode ? Colors.grey[900] : Colors.white,
+          elevation: 10,
+          selectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold),
+        ),
       ),
     );
   }
 }
-


### PR DESCRIPTION
 Solves this  #102
I've successfully added a bottom navigation bar to the admin dashboard with three options:

1. Home - Stays on the current admin dashboard
2. Analytics - Navigates to the Analytics Dashboard
3. Logout - Shows a confirmation dialog before signing out

***Key Changes Made***:

1.  **Bottom Navigation Bar**: 

 - Added a BottomNavigationBar in NagarVikas\lib\screen\analytics_dashboard.dart with three items
 -  Set the default selected index to 0 (Home)
 - Styled to match the app's theme

2. **Navigation Logic**:

- Implemented _onItemTapped in NagarVikas\lib\screen\analytics_dashboard.dart to handle navigation between screens
- Added smooth transitions between Home and Analytics
- Included a logout confirmation dialog

3. UI/UX Improvements:

- Consistent styling with the analytics dashboard
- Visual feedback for the selected tab
- Proper handling of dark/light theme

The navigation is now more intuitive and matches the functionality of the analytics dashboard. Users can easily switch between the main dashboard and analytics, or log out when needed.