### PR TITLE
Solved Messages Take too Much Horizontal Space Issue #437

### DIFF
--- a/lib/screen/discussion/message_widgets.dart
+++ b/lib/screen/discussion/message_widgets.dart
@@ -160,11 +160,14 @@ class MessageWidgets {
                                 messageData["senderName"] ?? "Unknown User",
                               );
                             },
+                            child: IntrinsicWidth(
                             child: AnimatedContainer(
                               duration: Duration(milliseconds: 300),
                               constraints: BoxConstraints(
-                                maxWidth:
-                                    MediaQuery.of(context).size.width * 0.75,
+                                minWidth:
+                                    50.0, // Minimum width for very short messages
+                                maxWidth: MediaQuery.of(context).size.width *
+                                    0.75, // Maximum width remains the same
                               ),
                               padding: EdgeInsets.symmetric(
                                 vertical:
@@ -236,7 +239,7 @@ class MessageWidgets {
                                   // Add highlight indicator at the top when highlighted
                                   if (_currentlyHighlighted)
                                     Container(
-                                      margin: EdgeInsets.only(bottom: 6),                                    
+                                      margin: EdgeInsets.only(bottom: 6),
                                       decoration: BoxDecoration(
                                         color: isMe
                                             ? Colors.white.withOpacity(0.2)
@@ -775,6 +778,7 @@ class MessageWidgets {
                                     ),
                                 ],
                               ),
+                            ),
                             ),
                           ),
                       ],


### PR DESCRIPTION
# 🚀 Pull Request

## ⭐ Repository Support
**Have you starred the repository?**
- [x] ⭐ Yes, I have starred the repository
---

## 📝 Description
Fix message width issue where short messages take full screen width, creating unbalanced UI and wasted horizontal space.

**Related Issue(s):**
- Fixes #437

---

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Style/UI improvement

---

## 🛠️ Changes Made
### Core Changes
- [x] UI/UX enhancements
- [x] Bug fixes

### Detailed Changes
1. **Message Width Optimization**: Modified message containers to use intrinsic width instead of full screen width
2. **Responsive Design**: Ensured messages still wrap properly on smaller screens
3. **UI Balance**: Improved visual hierarchy by making short messages more compact

### Files Modified
- `lib/screen/discussion/message_widgets.dart` - Updated message container width constraints

---

## 🧪 Testing
### Tested On
- [x] Mobile (iOS/Android)

### Manual Testing Checklist
- [x] Short messages no longer take full width
- [x] Long messages still wrap properly
- [x] Responsive design works on different screen sizes
- [x] No console errors or warnings

---

## ✅ Checklist
### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Git Hygiene
- [x] My commits are atomic and have descriptive messages
- [x] I have rebased/merged the latest main branch

### Project Specific
- [x] Visual/UI changes are accurate
- [x] Mobile/web responsiveness is preserved

---

## 🤝 Additional Notes
This change improves the visual balance of the discussion forum by making message widths more proportional to their content length, creating a cleaner and more professional appearance.

## 👥 Reviewers
@Prateek9876 